### PR TITLE
Revert "'Rel'-types in Embedded Link Entities"

### DIFF
--- a/src/SirenPHP/Entity.php
+++ b/src/SirenPHP/Entity.php
@@ -20,6 +20,11 @@ class Entity extends BaseEntity {
     }
 
     public function appendEntity(array $rel, BaseEntity $entity) {
+        foreach ($rel as $r) {
+            if (!is_string($r)) {
+                throw new \InvalidArgumentExcpetion('rel must be an array of strings')
+            }
+        }
         $copyEntity = clone $entity;
         $copyEntity->rel = $rel;
         $this->entities[] = $copyEntity;

--- a/src/SirenPHP/LinkedEntity.php
+++ b/src/SirenPHP/LinkedEntity.php
@@ -4,9 +4,8 @@ namespace SirenPHP;
 class LinkedEntity extends BaseEntity {
     private $href = null;
 
-    public function __construct($href, array $rel, array $class=array()) {
+    public function __construct($href, array $class=array()) {
         $this->setHref($href);
-        $this->setRel($rel);
         $this->setClass($class);
     }
 
@@ -16,17 +15,6 @@ class LinkedEntity extends BaseEntity {
         }
 
         $this->href = $href;
-        return $this;
-    }
-    
-    public function setRel($rel) {
-        foreach ($rel as $r) {
-            if (!is_string($r)) {
-                throw new \InvalidArgumentExcpetion('rel must be an array of strings')
-            }
-        }
-
-        $this->rel = $rel;
         return $this;
     }
 


### PR DESCRIPTION
Reverts jefersondaniel/sirenphp#3. 
Sorry, my bad. Sub-entities are always appended through Entity::appendEntity which sets the relation property.
Since LinkedEntities never exist on their own, it would be unreasonable to keep relations even as an optional argument in the constructor.
